### PR TITLE
Added ECDH-1PU (Draft 04) algorithm support to JWE

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Generic, spec-compliant implementation to build clients and providers:
   - [RFC7638: JSON Web Key (JWK) Thumbprint](https://docs.authlib.org/en/latest/specs/rfc7638.html)
   - [ ] RFC7797: JSON Web Signature (JWS) Unencoded Payload Option
   - [RFC8037: ECDH in JWS and JWE](https://docs.authlib.org/en/latest/specs/rfc8037.html)
+  - [ ] draft-madden-jose-ecdh-1pu-04: Public Key Authenticated Encryption for JOSE: ECDH-1PU
 - [OpenID Connect 1.0](https://docs.authlib.org/en/latest/specs/oidc.html)
   - [x] OpenID Connect Core 1.0
   - [x] OpenID Connect Discovery 1.0

--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,7 @@ Specifications
 - RFC8628: OAuth 2.0 Device Authorization Grant
 - OpenID Connect 1.0
 - OpenID Connect Discovery 1.0
+- draft-madden-jose-ecdh-1pu-04: Public Key Authenticated Encryption for JOSE: ECDH-1PU
 
 Implementations
 ---------------

--- a/authlib/jose/__init__.py
+++ b/authlib/jose/__init__.py
@@ -15,14 +15,14 @@ from .rfc7517 import Key, KeySet, JsonWebKey
 from .rfc7518 import (
     register_jws_rfc7518,
     register_jwe_rfc7518,
-    ECDHAlgorithm,
+    ECDHESAlgorithm,
     OctKey,
     RSAKey,
     ECKey,
 )
 from .rfc7519 import JsonWebToken, BaseClaims, JWTClaims
 from .rfc8037 import OKPKey, register_jws_rfc8037
-from .drafts import register_jwe_draft
+from .drafts import register_jwe_enc_draft, register_jwe_alg_draft, ECDH1PUAlgorithm
 
 from .errors import JoseError
 
@@ -31,10 +31,12 @@ register_jws_rfc7518(JsonWebSignature)
 register_jws_rfc8037(JsonWebSignature)
 
 register_jwe_rfc7518(JsonWebEncryption)
-register_jwe_draft(JsonWebEncryption)
+register_jwe_enc_draft(JsonWebEncryption)
+register_jwe_alg_draft(JsonWebEncryption)
 
 # attach algorithms
-ECDHAlgorithm.ALLOWED_KEY_CLS = (ECKey, OKPKey)
+ECDHESAlgorithm.ALLOWED_KEY_CLS = (ECKey, OKPKey)
+ECDH1PUAlgorithm.ALLOWED_KEY_CLS = (ECKey, OKPKey)
 
 # register supported keys
 JsonWebKey.JWK_KEY_CLS = {

--- a/authlib/jose/drafts/__init__.py
+++ b/authlib/jose/drafts/__init__.py
@@ -1,3 +1,8 @@
-from ._jwe_enc_cryptography import register_jwe_draft
+from ._jwe_enc_cryptography import register_jwe_enc_draft
+from ._jwe_algorithms import register_jwe_alg_draft, ECDH1PUAlgorithm
 
-__all__ = ['register_jwe_draft']
+__all__ = [
+    'register_jwe_enc_draft',
+    'register_jwe_alg_draft',
+    'ECDH1PUAlgorithm',
+]

--- a/authlib/jose/drafts/_jwe_algorithms.py
+++ b/authlib/jose/drafts/_jwe_algorithms.py
@@ -1,0 +1,175 @@
+import struct
+
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.concatkdf import ConcatKDFHash
+
+from authlib.jose.errors import InappropriateEncryptionAlgorithmError
+from authlib.jose.rfc7516 import JWEAlgorithmWithTagAwareKeyAgreement
+from authlib.jose.rfc7518.jwe_algs import AESAlgorithm, ECKey, u32be_len_input
+from authlib.jose.rfc7518.jwe_encs import CBCHS2EncAlgorithm
+
+
+class ECDH1PUAlgorithm(JWEAlgorithmWithTagAwareKeyAgreement):
+    EXTRA_HEADERS = ['epk', 'apu', 'apv', 'skid']
+    ALLOWED_KEY_CLS = ECKey
+
+    # https://datatracker.ietf.org/doc/html/draft-madden-jose-ecdh-1pu-04
+    def __init__(self, key_size=None):
+        if key_size is None:
+            self.name = 'ECDH-1PU'
+            self.description = 'ECDH-1PU in the Direct Key Agreement mode'
+        else:
+            self.name = 'ECDH-1PU+A{}KW'.format(key_size)
+            self.description = (
+                'ECDH-1PU using Concat KDF and CEK wrapped '
+                'with A{}KW').format(key_size)
+        self.key_size = key_size
+        self.aeskw = AESAlgorithm(key_size)
+
+    def prepare_key(self, raw_data):
+        if isinstance(raw_data, self.ALLOWED_KEY_CLS):
+            return raw_data
+        return ECKey.import_key(raw_data)
+
+    def compute_fixed_info(self, headers, bit_size, tag):
+        if tag is None:
+            cctag = b''
+        else:
+            cctag = u32be_len_input(tag)
+
+        # AlgorithmID
+        if self.key_size is None:
+            alg_id = u32be_len_input(headers['enc'])
+        else:
+            alg_id = u32be_len_input(headers['alg'])
+
+        # PartyUInfo
+        apu_info = u32be_len_input(headers.get('apu'), True)
+
+        # PartyVInfo
+        apv_info = u32be_len_input(headers.get('apv'), True)
+
+        # SuppPubInfo
+        pub_info = struct.pack('>I', bit_size) + cctag
+
+        return alg_id + apu_info + apv_info + pub_info
+
+    def deliver(self, shared_key, headers, bit_size, tag):
+        fixed_info = self.compute_fixed_info(headers, bit_size, tag)
+
+        ckdf = ConcatKDFHash(
+            algorithm=hashes.SHA256(),
+            length=bit_size // 8,
+            otherinfo=fixed_info,
+            backend=default_backend()
+        )
+        return ckdf.derive(shared_key)
+
+    def deliver_at_sender(self, sender_static_key, sender_ephemeral_key, recipient_pubkey, headers, bit_size, tag):
+        shared_key_s = sender_static_key.exchange_shared_key(recipient_pubkey)
+        shared_key_e = sender_ephemeral_key.exchange_shared_key(recipient_pubkey)
+        shared_key = shared_key_e + shared_key_s
+
+        return self.deliver(shared_key, headers, bit_size, tag)
+
+    def deliver_at_recipient(self, recipient_key, sender_static_pubkey, sender_ephemeral_pubkey, headers, bit_size, tag):
+        shared_key_s = recipient_key.exchange_shared_key(sender_static_pubkey)
+        shared_key_e = recipient_key.exchange_shared_key(sender_ephemeral_pubkey)
+        shared_key = shared_key_e + shared_key_s
+
+        return self.deliver(shared_key, headers, bit_size, tag)
+
+    def generate_ephemeral_key(self, key):
+        return key.generate_key(key['crv'], is_private=True)
+
+    def prepare_headers(self, sender_key, epk):
+        h = {}
+
+        if sender_key.kid:
+            # TODO: Should we overwrite "skid" if it has already been set?
+            h['skid'] = sender_key.kid
+
+        # REQUIRED_JSON_FIELDS contains only public fields
+        pub_epk = {k: epk[k] for k in epk.REQUIRED_JSON_FIELDS}
+        pub_epk['kty'] = epk.kty
+        h['epk'] = pub_epk
+
+        return h
+
+    def generate_keys_and_prepare_headers(self, enc_alg, key, sender_key):
+        if not isinstance(enc_alg, CBCHS2EncAlgorithm):
+            raise InappropriateEncryptionAlgorithmError(enc_alg.name, self.name)
+
+        epk = self.generate_ephemeral_key(key)
+        cek = enc_alg.generate_cek()
+        h = self.prepare_headers(sender_key, epk)
+
+        return {'epk': epk, 'cek': cek, 'header': h}
+
+    def agree_upon_key_at_sender(self, enc_alg, headers, key, sender_key, epk, tag=None):
+        if self.key_size is None:
+            bit_size = enc_alg.key_size
+        else:
+            bit_size = self.key_size
+
+        public_key = key.get_op_key('wrapKey')
+
+        return self.deliver_at_sender(sender_key, epk, public_key, headers, bit_size, tag)
+
+    def wrap_cek(self, cek, dk):
+        kek = self.aeskw.prepare_key(dk)
+        return self.aeskw.wrap_cek(cek, kek)
+
+    def agree_upon_key_and_wrap_cek(self, enc_alg, headers, key, sender_key, epk, cek, tag):
+        dk = self.agree_upon_key_at_sender(enc_alg, headers, key, sender_key, epk, tag)
+        return self.wrap_cek(cek, dk)
+
+    def wrap(self, enc_alg, headers, key, sender_key):
+        # In this class this method is used in direct key agreement mode only
+        if self.key_size is not None:
+            raise RuntimeError('Invalid algorithm state detected')
+
+        epk = self.generate_ephemeral_key(key)
+        h = self.prepare_headers(sender_key, epk)
+
+        dk = self.agree_upon_key_at_sender(enc_alg, headers, key, sender_key, epk)
+
+        return {'ek': b'', 'cek': dk, 'header': h}
+
+    def unwrap(self, enc_alg, ek, headers, key, sender_key, tag=None):
+        if 'epk' not in headers:
+            raise ValueError('Missing "epk" in headers')
+
+        # TODO: Should we validate "skid" value correctness?
+        if 'skid' in headers and sender_key.kid and sender_key.kid != headers['skid']:
+            raise ValueError('"kid" of sender\'s key is not equal to "skid"');
+
+        if self.key_size is None:
+            bit_size = enc_alg.key_size
+        else:
+            bit_size = self.key_size
+
+        sender_pubkey = sender_key.get_op_key('wrapKey')
+        epk = key.import_key(headers['epk'])
+        epk_pubkey = epk.get_op_key('wrapKey')
+        dk = self.deliver_at_recipient(key, sender_pubkey, epk_pubkey, headers, bit_size, tag)
+
+        if self.key_size is None:
+            return dk
+
+        kek = self.aeskw.prepare_key(dk)
+        return self.aeskw.unwrap(enc_alg, ek, headers, kek)
+
+
+JWE_DRAFT_ALG_ALGORITHMS = [
+    ECDH1PUAlgorithm(None),  # ECDH-1PU
+    ECDH1PUAlgorithm(128),  # ECDH-1PU+A128KW
+    ECDH1PUAlgorithm(192),  # ECDH-1PU+A192KW
+    ECDH1PUAlgorithm(256),  # ECDH-1PU+A256KW
+]
+
+
+def register_jwe_alg_draft(cls):
+    for alg in JWE_DRAFT_ALG_ALGORITHMS:
+        cls.register_algorithm(alg)

--- a/authlib/jose/drafts/_jwe_algorithms.py
+++ b/authlib/jose/drafts/_jwe_algorithms.py
@@ -109,7 +109,7 @@ class ECDH1PUAlgorithm(JWEAlgorithmWithTagAwareKeyAgreement):
 
     def agree_upon_key_at_sender(self, enc_alg, headers, key, sender_key, epk, tag=None):
         if self.key_size is None:
-            bit_size = enc_alg.key_size
+            bit_size = enc_alg.CEK_SIZE
         else:
             bit_size = self.key_size
 
@@ -146,7 +146,7 @@ class ECDH1PUAlgorithm(JWEAlgorithmWithTagAwareKeyAgreement):
             raise ValueError('"kid" of sender\'s key is not equal to "skid"');
 
         if self.key_size is None:
-            bit_size = enc_alg.key_size
+            bit_size = enc_alg.CEK_SIZE
         else:
             bit_size = self.key_size
 

--- a/authlib/jose/drafts/_jwe_algorithms.py
+++ b/authlib/jose/drafts/_jwe_algorithms.py
@@ -84,18 +84,10 @@ class ECDH1PUAlgorithm(JWEAlgorithmWithTagAwareKeyAgreement):
         return key.generate_key(key['crv'], is_private=True)
 
     def prepare_headers(self, sender_key, epk):
-        h = {}
-
-        if sender_key.kid:
-            # TODO: Should we overwrite "skid" if it has already been set?
-            h['skid'] = sender_key.kid
-
         # REQUIRED_JSON_FIELDS contains only public fields
         pub_epk = {k: epk[k] for k in epk.REQUIRED_JSON_FIELDS}
         pub_epk['kty'] = epk.kty
-        h['epk'] = pub_epk
-
-        return h
+        return {'epk': pub_epk}
 
     def generate_keys_and_prepare_headers(self, enc_alg, key, sender_key):
         if not isinstance(enc_alg, CBCHS2EncAlgorithm):
@@ -140,10 +132,6 @@ class ECDH1PUAlgorithm(JWEAlgorithmWithTagAwareKeyAgreement):
     def unwrap(self, enc_alg, ek, headers, key, sender_key, tag=None):
         if 'epk' not in headers:
             raise ValueError('Missing "epk" in headers')
-
-        # TODO: Should we validate "skid" value correctness?
-        if 'skid' in headers and sender_key.kid and sender_key.kid != headers['skid']:
-            raise ValueError('"kid" of sender\'s key is not equal to "skid"');
 
         if self.key_size is None:
             bit_size = enc_alg.CEK_SIZE

--- a/authlib/jose/drafts/_jwe_enc_cryptography.py
+++ b/authlib/jose/drafts/_jwe_enc_cryptography.py
@@ -50,5 +50,5 @@ class C20PEncAlgorithm(JWEEncAlgorithm):
         return chacha.decrypt(iv, ciphertext + tag, aad)
 
 
-def register_jwe_draft(cls):
+def register_jwe_enc_draft(cls):
     cls.register_algorithm(C20PEncAlgorithm(256))  # C20P

--- a/authlib/jose/errors.py
+++ b/authlib/jose/errors.py
@@ -25,12 +25,21 @@ class BadSignatureError(JoseError):
         self.result = result
 
 
-class InvalidHeaderParameterName(JoseError):
+class InvalidHeaderParameterNameError(JoseError):
     error = 'invalid_header_parameter_name'
 
     def __init__(self, name):
         description = 'Invalid Header Parameter Names: {}'.format(name)
-        super(InvalidHeaderParameterName, self).__init__(
+        super(InvalidHeaderParameterNameError, self).__init__(
+            description=description)
+
+
+class InappropriateEncryptionAlgorithmError(JoseError):
+    error = 'inappropriate_encryption_algorithm'
+
+    def __init__(self, enc, alg):
+        description = '{} encryption algorithm is inappropriate for {} algorithm'.format(enc, alg)
+        super(InappropriateEncryptionAlgorithmError, self).__init__(
             description=description)
 
 

--- a/authlib/jose/errors.py
+++ b/authlib/jose/errors.py
@@ -34,12 +34,13 @@ class InvalidHeaderParameterNameError(JoseError):
             description=description)
 
 
-class InappropriateEncryptionAlgorithmError(JoseError):
-    error = 'inappropriate_encryption_algorithm'
+class InvalidEncryptionAlgorithmForECDH1PUWithKeyWrappingError(JoseError):
+    error = 'invalid_encryption_algorithm_for_ECDH_1PU_with_key_wrapping'
 
-    def __init__(self, enc, alg):
-        description = '{} encryption algorithm is inappropriate for {} algorithm'.format(enc, alg)
-        super(InappropriateEncryptionAlgorithmError, self).__init__(
+    def __init__(self):
+        description = 'In key agreement with key wrapping mode ECDH-1PU algorithm ' \
+                      'only supports AES_CBC_HMAC_SHA2 family encryption algorithms'
+        super(InvalidEncryptionAlgorithmForECDH1PUWithKeyWrappingError, self).__init__(
             description=description)
 
 

--- a/authlib/jose/rfc7515/jws.py
+++ b/authlib/jose/rfc7515/jws.py
@@ -14,7 +14,7 @@ from authlib.jose.errors import (
     MissingAlgorithmError,
     UnsupportedAlgorithmError,
     BadSignatureError,
-    InvalidHeaderParameterName,
+    InvalidHeaderParameterNameError,
 )
 from .models import JWSHeader, JWSObject
 
@@ -267,7 +267,7 @@ class JsonWebSignature(object):
 
             for k in header:
                 if k not in names:
-                    raise InvalidHeaderParameterName(k)
+                    raise InvalidHeaderParameterNameError(k)
 
     def _validate_json_jws(self, payload_segment, payload, header_obj, key):
         protected_segment = header_obj.get('protected')

--- a/authlib/jose/rfc7516/__init__.py
+++ b/authlib/jose/rfc7516/__init__.py
@@ -9,10 +9,10 @@
 """
 
 from .jwe import JsonWebEncryption
-from .models import JWEAlgorithm, JWEEncAlgorithm, JWEZipAlgorithm
+from .models import JWEAlgorithm, JWEAlgorithmWithTagAwareKeyAgreement, JWEEncAlgorithm, JWEZipAlgorithm
 
 
 __all__ = [
     'JsonWebEncryption',
-    'JWEAlgorithm', 'JWEEncAlgorithm', 'JWEZipAlgorithm'
+    'JWEAlgorithm', 'JWEAlgorithmWithTagAwareKeyAgreement', 'JWEEncAlgorithm', 'JWEZipAlgorithm'
 ]

--- a/authlib/jose/rfc7516/jwe.py
+++ b/authlib/jose/rfc7516/jwe.py
@@ -92,8 +92,7 @@ class JsonWebEncryption(object):
             prep = alg.generate_keys_and_prepare_headers(enc, key, sender_key)
             epk = prep['epk']
             cek = prep['cek']
-            if 'header' in prep:
-                protected.update(prep['header'])
+            protected.update(prep['header'])
         else:
             # In any other case:
             # Keep the normal steps order defined by RFC 7516

--- a/authlib/jose/rfc7516/jwe.py
+++ b/authlib/jose/rfc7516/jwe.py
@@ -1,6 +1,7 @@
 from authlib.common.encoding import (
     to_bytes, urlsafe_b64encode, json_b64encode
 )
+from authlib.jose.rfc7516.models import JWEAlgorithmWithTagAwareKeyAgreement
 from authlib.jose.util import (
     extract_header,
     extract_segment,
@@ -12,7 +13,7 @@ from authlib.jose.errors import (
     MissingEncryptionAlgorithmError,
     UnsupportedEncryptionAlgorithmError,
     UnsupportedCompressionAlgorithmError,
-    InvalidHeaderParameterName,
+    InvalidHeaderParameterNameError,
 )
 
 
@@ -47,7 +48,7 @@ class JsonWebEncryption(object):
         elif algorithm.algorithm_location == 'zip':
             cls.ZIP_REGISTRY[algorithm.name] = algorithm
 
-    def serialize_compact(self, protected, payload, key):
+    def serialize_compact(self, protected, payload, key, sender_key=None):
         """Generate a JWE Compact Serialization. The JWE Compact Serialization
         represents encrypted content as a compact, URL-safe string.  This
         string is:
@@ -64,7 +65,8 @@ class JsonWebEncryption(object):
 
         :param protected: A dict of protected header
         :param payload: A string/dict of payload
-        :param key: Private key used to generate signature
+        :param key: Public key used to encrypt payload
+        :param sender_key: Sender's private key if needed by the key agreement algorithm being used
         :return: byte
         """
 
@@ -75,18 +77,31 @@ class JsonWebEncryption(object):
         self._validate_private_headers(protected, alg)
 
         key = prepare_key(alg, protected, key)
+        if sender_key is not None:
+            sender_key = alg.prepare_key(sender_key)
 
         # self._post_validate_header(protected, algorithm)
 
         # step 2: Generate a random Content Encryption Key (CEK)
-        # use enc_alg.generate_cek() in .wrap method
+        # use enc_alg.generate_cek() in scope of upcoming .wrap or .generate_keys_and_prepare_headers call
 
         # step 3: Encrypt the CEK with the recipient's public key
-        wrapped = alg.wrap(enc, protected, key)
-        cek = wrapped['cek']
-        ek = wrapped['ek']
-        if 'header' in wrapped:
-            protected.update(wrapped['header'])
+        if isinstance(alg, JWEAlgorithmWithTagAwareKeyAgreement) and alg.key_size is not None:
+            # For a JWE algorithm with tag-aware key agreement in case key agreement with key wrapping mode is used:
+            # Defer key agreement with key wrapping until authentication tag is computed
+            prep = alg.generate_keys_and_prepare_headers(enc, key, sender_key)
+            epk = prep['epk']
+            cek = prep['cek']
+            if 'header' in prep:
+                protected.update(prep['header'])
+        else:
+            # In any other case:
+            # Keep the normal steps order defined by RFC 7516
+            wrapped = alg.wrap(enc, protected, key, sender_key)
+            cek = wrapped['cek']
+            ek = wrapped['ek']
+            if 'header' in wrapped:
+                protected.update(wrapped['header'])
 
         # step 4: Generate a random JWE Initialization Vector
         iv = enc.generate_iv()
@@ -104,6 +119,14 @@ class JsonWebEncryption(object):
 
         # step 7: perform encryption
         ciphertext, tag = enc.encrypt(msg, aad, iv, cek)
+
+        if isinstance(alg, JWEAlgorithmWithTagAwareKeyAgreement) and alg.key_size is not None:
+            # For a JWE algorithm with tag-aware key agreement in case key agreement with key wrapping mode is used:
+            # Perform key agreement with key wrapping deferred at step 3
+            wrapped = alg.agree_upon_key_and_wrap_cek(enc, protected, key, sender_key, epk, cek, tag)
+            ek = wrapped['ek']
+
+        # step 8: build resulting message
         return b'.'.join([
             protected_segment,
             urlsafe_b64encode(ek),
@@ -112,12 +135,13 @@ class JsonWebEncryption(object):
             urlsafe_b64encode(tag)
         ])
 
-    def deserialize_compact(self, s, key, decode=None):
+    def deserialize_compact(self, s, key, decode=None, sender_key=None):
         """Exact JWS Compact Serialization, and validate with the given key.
 
         :param s: text of JWS Compact Serialization
-        :param key: key used to verify the signature
+        :param key: private key used to decrypt payload
         :param decode: a function to decode plaintext data
+        :param sender_key: sender's public key if needed by the key agreement algorithm being used
         :return: dict
         """
         try:
@@ -138,8 +162,18 @@ class JsonWebEncryption(object):
         self._validate_private_headers(protected, alg)
 
         key = prepare_key(alg, protected, key)
+        if sender_key is not None:
+            sender_key = alg.prepare_key(sender_key)
 
-        cek = alg.unwrap(enc, ek, protected, key)
+        if isinstance(alg, JWEAlgorithmWithTagAwareKeyAgreement) and alg.key_size is not None:
+            # For a JWE algorithm with tag-aware key agreement in case key agreement with key wrapping mode is used:
+            # Provide authentication tag to .unwrap method
+            cek = alg.unwrap(enc, ek, protected, key, sender_key, tag)
+        else:
+            # In any other case:
+            # Don't provide authentication tag to .unwrap method
+            cek = alg.unwrap(enc, ek, protected, key, sender_key)
+
         aad = to_bytes(protected_s, 'ascii')
         msg = enc.decrypt(ciphertext, aad, iv, tag, cek)
 
@@ -196,7 +230,7 @@ class JsonWebEncryption(object):
 
         for k in header:
             if k not in names:
-                raise InvalidHeaderParameterName(k)
+                raise InvalidHeaderParameterNameError(k)
 
 
 def prepare_key(alg, header, key):

--- a/authlib/jose/rfc7516/models.py
+++ b/authlib/jose/rfc7516/models.py
@@ -15,10 +15,22 @@ class JWEAlgorithm(object):
     def prepare_key(self, raw_data):
         raise NotImplementedError
 
-    def wrap(self, enc_alg, headers, key):
+    def wrap(self, enc_alg, headers, key, sender_key):
         raise NotImplementedError
 
-    def unwrap(self, enc_alg, ek, headers, key):
+    def unwrap(self, enc_alg, ek, headers, key, sender_key, tag):
+        raise NotImplementedError
+
+
+class JWEAlgorithmWithTagAwareKeyAgreement(JWEAlgorithm):
+    """Interface for JWE algorithm with tag-aware key agreement (in key agreement with key wrapping mode).
+    ECDH-1PU is an example of such an algorithm.
+    """
+
+    def generate_keys_and_prepare_headers(self, enc_alg, key, sender_key):
+        raise NotImplementedError
+
+    def agree_upon_key_and_wrap_cek(self, enc_alg, headers, key, sender_key, epk, cek, tag):
         raise NotImplementedError
 
 

--- a/authlib/jose/rfc7518/__init__.py
+++ b/authlib/jose/rfc7518/__init__.py
@@ -2,7 +2,7 @@ from .oct_key import OctKey
 from .rsa_key import RSAKey
 from .ec_key import ECKey
 from .jws_algs import JWS_ALGORITHMS
-from .jwe_algs import JWE_ALG_ALGORITHMS, ECDHAlgorithm
+from .jwe_algs import JWE_ALG_ALGORITHMS, ECDHESAlgorithm
 from .jwe_encs import JWE_ENC_ALGORITHMS
 from .jwe_zips import DeflateZipAlgorithm
 
@@ -28,5 +28,5 @@ __all__ = [
     'OctKey',
     'RSAKey',
     'ECKey',
-    'ECDHAlgorithm',
+    'ECDHESAlgorithm',
 ]

--- a/authlib/jose/rfc7518/ec_key.py
+++ b/authlib/jose/rfc7518/ec_key.py
@@ -36,7 +36,7 @@ class ECKey(AsymmetricKey):
     SSH_PUBLIC_PREFIX = b'ecdsa-sha2-'
 
     def exchange_shared_key(self, pubkey):
-        # # used in ECDHAlgorithm
+        # # used in ECDHESAlgorithm
         private_key = self.get_private_key()
         if private_key:
             return private_key.exchange(ec.ECDH(), pubkey)

--- a/authlib/jose/rfc7518/jwe_algs.py
+++ b/authlib/jose/rfc7518/jwe_algs.py
@@ -187,7 +187,7 @@ class ECDHESAlgorithm(JWEAlgorithm):
             return raw_data
         return ECKey.import_key(raw_data)
 
-    def compute_fixed_info(self, headers, bit_size):
+    def _compute_fixed_info(self, headers, bit_size):
         # AlgorithmID
         if self.key_size is None:
             alg_id = u32be_len_input(headers['enc'])
@@ -207,7 +207,7 @@ class ECDHESAlgorithm(JWEAlgorithm):
 
     def deliver(self, key, pubkey, headers, bit_size):
         shared_key = key.exchange_shared_key(pubkey)
-        fixed_info = self.compute_fixed_info(headers, bit_size)
+        fixed_info = self._compute_fixed_info(headers, bit_size)
 
         ckdf = ConcatKDFHash(
             algorithm=hashes.SHA256(),

--- a/authlib/jose/rfc7518/jwe_algs.py
+++ b/authlib/jose/rfc7518/jwe_algs.py
@@ -67,7 +67,6 @@ class RSAAlgorithm(JWEAlgorithm):
         # it will raise ValueError if failed
         op_key = key.get_op_key('unwrapKey')
         cek = op_key.decrypt(ek, self.padding)
-        print(cek, enc_alg.key_size)
         if len(cek) * 8 != enc_alg.CEK_SIZE:
             raise ValueError('Invalid "cek" length')
         return cek
@@ -220,7 +219,7 @@ class ECDHESAlgorithm(JWEAlgorithm):
 
     def wrap(self, enc_alg, headers, key, sender_key=None):
         if self.key_size is None:
-            bit_size = enc_alg.key_size
+            bit_size = enc_alg.CEK_SIZE
         else:
             bit_size = self.key_size
 
@@ -245,7 +244,7 @@ class ECDHESAlgorithm(JWEAlgorithm):
             raise ValueError('Missing "epk" in headers')
 
         if self.key_size is None:
-            bit_size = enc_alg.key_size
+            bit_size = enc_alg.CEK_SIZE
         else:
             bit_size = self.key_size
 

--- a/authlib/jose/rfc7518/jwe_algs.py
+++ b/authlib/jose/rfc7518/jwe_algs.py
@@ -29,13 +29,13 @@ class DirectAlgorithm(JWEAlgorithm):
     def prepare_key(self, raw_data):
         return OctKey.import_key(raw_data)
 
-    def wrap(self, enc_alg, headers, key):
+    def wrap(self, enc_alg, headers, key, sender_key=None):
         cek = key.get_op_key('encrypt')
         if len(cek) * 8 != enc_alg.CEK_SIZE:
             raise ValueError('Invalid "cek" length')
         return {'ek': b'', 'cek': cek}
 
-    def unwrap(self, enc_alg, ek, headers, key):
+    def unwrap(self, enc_alg, ek, headers, key, sender_key=None, tag=None):
         cek = key.get_op_key('decrypt')
         if len(cek) * 8 != enc_alg.CEK_SIZE:
             raise ValueError('Invalid "cek" length')
@@ -55,7 +55,7 @@ class RSAAlgorithm(JWEAlgorithm):
     def prepare_key(self, raw_data):
         return RSAKey.import_key(raw_data)
 
-    def wrap(self, enc_alg, headers, key):
+    def wrap(self, enc_alg, headers, key, sender_key=None):
         cek = enc_alg.generate_cek()
         op_key = key.get_op_key('wrapKey')
         if op_key.key_size < self.key_size:
@@ -63,7 +63,7 @@ class RSAAlgorithm(JWEAlgorithm):
         ek = op_key.encrypt(cek, self.padding)
         return {'ek': ek, 'cek': cek}
 
-    def unwrap(self, enc_alg, ek, headers, key):
+    def unwrap(self, enc_alg, ek, headers, key, sender_key=None, tag=None):
         # it will raise ValueError if failed
         op_key = key.get_op_key('unwrapKey')
         cek = op_key.decrypt(ek, self.padding)
@@ -87,14 +87,17 @@ class AESAlgorithm(JWEAlgorithm):
             raise ValueError(
                 'A key of size {} bits is required.'.format(self.key_size))
 
-    def wrap(self, enc_alg, headers, key):
-        cek = enc_alg.generate_cek()
+    def wrap_cek(self, cek, key):
         op_key = key.get_op_key('wrapKey')
         self._check_key(op_key)
         ek = aes_key_wrap(op_key, cek, default_backend())
         return {'ek': ek, 'cek': cek}
 
-    def unwrap(self, enc_alg, ek, headers, key):
+    def wrap(self, enc_alg, headers, key, sender_key=None):
+        cek = enc_alg.generate_cek()
+        return self.wrap_cek(cek, key)
+
+    def unwrap(self, enc_alg, ek, headers, key, sender_key=None, tag=None):
         op_key = key.get_op_key('unwrapKey')
         self._check_key(op_key)
         cek = aes_key_unwrap(op_key, ek, default_backend())
@@ -119,7 +122,7 @@ class AESGCMAlgorithm(JWEAlgorithm):
             raise ValueError(
                 'A key of size {} bits is required.'.format(self.key_size))
 
-    def wrap(self, enc_alg, headers, key):
+    def wrap(self, enc_alg, headers, key, sender_key=None):
         cek = enc_alg.generate_cek()
         op_key = key.get_op_key('wrapKey')
         self._check_key(op_key)
@@ -140,7 +143,7 @@ class AESGCMAlgorithm(JWEAlgorithm):
         }
         return {'ek': ek, 'cek': cek, 'header': h}
 
-    def unwrap(self, enc_alg, ek, headers, key):
+    def unwrap(self, enc_alg, ek, headers, key, sender_key=None, tag=None):
         op_key = key.get_op_key('unwrapKey')
         self._check_key(op_key)
 
@@ -163,7 +166,7 @@ class AESGCMAlgorithm(JWEAlgorithm):
         return cek
 
 
-class ECDHAlgorithm(JWEAlgorithm):
+class ECDHESAlgorithm(JWEAlgorithm):
     EXTRA_HEADERS = ['epk', 'apu', 'apv']
     ALLOWED_KEY_CLS = ECKey
 
@@ -185,33 +188,37 @@ class ECDHAlgorithm(JWEAlgorithm):
             return raw_data
         return ECKey.import_key(raw_data)
 
-    def deliver(self, key, pubkey, headers, bit_size):
+    def compute_fixed_info(self, headers, bit_size):
         # AlgorithmID
         if self.key_size is None:
-            alg_id = _u32be_len_input(headers['enc'])
+            alg_id = u32be_len_input(headers['enc'])
         else:
-            alg_id = _u32be_len_input(headers['alg'])
+            alg_id = u32be_len_input(headers['alg'])
 
         # PartyUInfo
-        apu_info = _u32be_len_input(headers.get('apu'), True)
+        apu_info = u32be_len_input(headers.get('apu'), True)
 
         # PartyVInfo
-        apv_info = _u32be_len_input(headers.get('apv'), True)
+        apv_info = u32be_len_input(headers.get('apv'), True)
 
         # SuppPubInfo
         pub_info = struct.pack('>I', bit_size)
 
-        other_info = alg_id + apu_info + apv_info + pub_info
+        return alg_id + apu_info + apv_info + pub_info
+
+    def deliver(self, key, pubkey, headers, bit_size):
         shared_key = key.exchange_shared_key(pubkey)
+        fixed_info = self.compute_fixed_info(headers, bit_size)
+
         ckdf = ConcatKDFHash(
             algorithm=hashes.SHA256(),
             length=bit_size // 8,
-            otherinfo=other_info,
+            otherinfo=fixed_info,
             backend=default_backend()
         )
         return ckdf.derive(shared_key)
 
-    def wrap(self, enc_alg, headers, key):
+    def wrap(self, enc_alg, headers, key, sender_key=None):
         if self.key_size is None:
             bit_size = enc_alg.key_size
         else:
@@ -233,7 +240,7 @@ class ECDHAlgorithm(JWEAlgorithm):
         rv['header'] = h
         return rv
 
-    def unwrap(self, enc_alg, ek, headers, key):
+    def unwrap(self, enc_alg, ek, headers, key, sender_key=None, tag=None):
         if 'epk' not in headers:
             raise ValueError('Missing "epk" in headers')
 
@@ -253,7 +260,7 @@ class ECDHAlgorithm(JWEAlgorithm):
         return self.aeskw.unwrap(enc_alg, ek, headers, kek)
 
 
-def _u32be_len_input(s, base64=False):
+def u32be_len_input(s, base64=False):
     if not s:
         return b'\x00\x00\x00\x00'
     if base64:
@@ -279,10 +286,10 @@ JWE_ALG_ALGORITHMS = [
     AESGCMAlgorithm(128),  # A128GCMKW
     AESGCMAlgorithm(192),  # A192GCMKW
     AESGCMAlgorithm(256),  # A256GCMKW
-    ECDHAlgorithm(None),  # ECDH-ES
-    ECDHAlgorithm(128),  # ECDH-ES+A128KW
-    ECDHAlgorithm(192),  # ECDH-ES+A192KW
-    ECDHAlgorithm(256),  # ECDH-ES+A256KW
+    ECDHESAlgorithm(None),  # ECDH-ES
+    ECDHESAlgorithm(128),  # ECDH-ES+A128KW
+    ECDHESAlgorithm(192),  # ECDH-ES+A192KW
+    ECDHESAlgorithm(256),  # ECDH-ES+A256KW
 ]
 
 # 'PBES2-HS256+A128KW': '',

--- a/authlib/jose/rfc8037/okp_key.py
+++ b/authlib/jose/rfc8037/okp_key.py
@@ -46,7 +46,7 @@ class OKPKey(AsymmetricKey):
     SSH_PUBLIC_PREFIX = b'ssh-ed25519'
 
     def exchange_shared_key(self, pubkey):
-        # used in ECDHAlgorithm
+        # used in ECDHESAlgorithm
         if self.private_key and isinstance(self.private_key, (X25519PrivateKey, X448PrivateKey)):
             return self.private_key.exchange(pubkey)
         raise ValueError('Invalid key for exchanging shared key')

--- a/authlib/jose/rfc8037/okp_key.py
+++ b/authlib/jose/rfc8037/okp_key.py
@@ -47,8 +47,9 @@ class OKPKey(AsymmetricKey):
 
     def exchange_shared_key(self, pubkey):
         # used in ECDHESAlgorithm
-        if self.private_key and isinstance(self.private_key, (X25519PrivateKey, X448PrivateKey)):
-            return self.private_key.exchange(pubkey)
+        private_key = self.get_private_key()
+        if private_key and isinstance(private_key, (X25519PrivateKey, X448PrivateKey)):
+            return private_key.exchange(pubkey)
         raise ValueError('Invalid key for exchanging shared key')
 
     @staticmethod

--- a/tests/core/test_jose/test_jwe.py
+++ b/tests/core/test_jose/test_jwe.py
@@ -450,7 +450,7 @@ class JWETest(unittest.TestCase):
             "d": "VEmDZpDXXK8p8N0Cndsxs924q6nS1RXFASRl6BfUqdw"
         }
         for alg, enc in [
-            ('ECDH-1PU', 'A256GCM'),
+            ('ECDH-1PU', 'A256CBC-HS512'),
             ('ECDH-1PU+A128KW', 'A256CBC-HS512'),
             ('ECDH-1PU+A192KW', 'A256CBC-HS512'),
             ('ECDH-1PU+A256KW', 'A256CBC-HS512'),
@@ -465,7 +465,7 @@ class JWETest(unittest.TestCase):
         alice_key = OKPKey.generate_key('X25519', is_private=True)
         bob_key = OKPKey.generate_key('X25519', is_private=True)
         for alg, enc in [
-            ('ECDH-1PU', 'A256GCM'),
+            ('ECDH-1PU', 'A256CBC-HS512'),
             ('ECDH-1PU+A128KW', 'A256CBC-HS512'),
             ('ECDH-1PU+A192KW', 'A256CBC-HS512'),
             ('ECDH-1PU+A256KW', 'A256CBC-HS512'),

--- a/tests/core/test_jose/test_jwe.py
+++ b/tests/core/test_jose/test_jwe.py
@@ -641,6 +641,42 @@ class JWETest(unittest.TestCase):
             protected, b'hello', bob_key, sender_key=alice_key
         )
 
+        alice_key = OKPKey.import_key({
+            "kty": "OKP",
+            "crv": "X25519",
+            "x": "TAB1oIsjPob3guKwTEeQsAsupSRPdXdxHhnV8JrVJTA",
+            "d": "kO2LzPr4vLg_Hn-7_MDq66hJZgvTIkzDG4p6nCsgNHk"
+        })  # the point is indeed on X25519 curve
+        bob_key = OKPKey.import_key({
+            "kty": "OKP",
+            "crv": "X25519",
+            "x": "lVHcPx4R9bExaoxXZY9tAq7SNW9pJKCoVQxURLtkAs3Dg5ZRxcjhf0JUyg2lod5OGDptJ7wowwY"
+        })  # the point is not on X25519 curve but is actually on X448 curve
+
+        self.assertRaises(
+            ValueError,
+            jwe.serialize_compact,
+            protected, b'hello', bob_key, sender_key=alice_key
+        )
+
+        alice_key = OKPKey.import_key({
+            "kty": "OKP",
+            "crv": "X448",
+            "x": "TAB1oIsjPob3guKwTEeQsAsupSRPdXdxHhnV8JrVJTA",
+            "d": "kO2LzPr4vLg_Hn-7_MDq66hJZgvTIkzDG4p6nCsgNHk"
+        })  # the point is not on X448 curve but is actually on X25519 curve
+        bob_key = OKPKey.import_key({
+            "kty": "OKP",
+            "crv": "X448",
+            "x": "lVHcPx4R9bExaoxXZY9tAq7SNW9pJKCoVQxURLtkAs3Dg5ZRxcjhf0JUyg2lod5OGDptJ7wowwY"
+        })  # the point is indeed on X448 curve
+
+        self.assertRaises(
+            ValueError,
+            jwe.serialize_compact,
+            protected, b'hello', bob_key, sender_key=alice_key
+        )
+
     def test_ecdh_1pu_encryption_fails_if_keys_curve_is_inappropriate(self):
         jwe = JsonWebEncryption()
         protected = {'alg': 'ECDH-1PU', 'enc': 'A256GCM'}

--- a/tests/core/test_jose/test_jwe.py
+++ b/tests/core/test_jose/test_jwe.py
@@ -1,9 +1,11 @@
 import os
 import unittest
+from collections import OrderedDict
+
 from authlib.jose import errors
 from authlib.jose import OctKey, OKPKey
 from authlib.jose import JsonWebEncryption
-from authlib.common.encoding import urlsafe_b64encode
+from authlib.common.encoding import urlsafe_b64encode, json_b64encode, to_bytes
 from tests.util import read_file_path
 
 
@@ -182,11 +184,19 @@ class JWETest(unittest.TestCase):
             "y": "e8lnCO-AlStT-NJVX-crhB7QRYhiix03illJOVAOyck",
             "d": "VEmDZpDXXK8p8N0Cndsxs924q6nS1RXFASRl6BfUqdw"
         }
+
         headers = {
             "alg": "ECDH-ES",
             "enc": "A128GCM",
             "apu": "QWxpY2U",
-            "apv": "Qm9i"
+            "apv": "Qm9i",
+            "epk":
+                {
+                    "kty": "EC",
+                    "crv": "P-256",
+                    "x": "gI0GAILBdu7T53akrFmMyGcsF3n5dO7MmwNBHKW5SV0",
+                    "y": "SLW_xSffzlPWrHEVI30DHM_4egVwt3NQqeUD7nMFpps"
+                }
         }
 
         alg = JsonWebEncryption.ALG_REGISTRY['ECDH-ES']
@@ -201,7 +211,7 @@ class JWETest(unittest.TestCase):
         self.assertEqual(urlsafe_b64encode(dk_at_alice), b'VqqN6vgjbSBcIijNcacQGg')
 
         dk_at_bob = alg.deliver(bob_static_key, alice_ephemeral_pubkey, headers, 128)
-        self.assertEqual(urlsafe_b64encode(dk_at_bob), b'VqqN6vgjbSBcIijNcacQGg')
+        self.assertEqual(dk_at_bob, dk_at_alice)
 
     def test_ecdh_es_jwe(self):
         jwe = JsonWebEncryption()
@@ -255,7 +265,7 @@ class JWETest(unittest.TestCase):
             protected, b'hello', key
         )
 
-    def test_ecdh_1pu_key_agreement_computation(self):
+    def test_ecdh_1pu_key_agreement_computation_appx_a(self):
         # https://datatracker.ietf.org/doc/html/draft-madden-jose-ecdh-1pu-04#appendix-A
         alice_static_key = {
             "kty": "EC",
@@ -278,11 +288,18 @@ class JWETest(unittest.TestCase):
             "y": "SLW_xSffzlPWrHEVI30DHM_4egVwt3NQqeUD7nMFpps",
             "d": "0_NxaRPUMQoAJt50Gz8YiTr8gRTwyEaCumd-MToTmIo"
         }
+
         headers = {
             "alg": "ECDH-1PU",
             "enc": "A256GCM",
             "apu": "QWxpY2U",
-            "apv": "Qm9i"
+            "apv": "Qm9i",
+            "epk": {
+                "kty": "EC",
+                "crv": "P-256",
+                "x": "gI0GAILBdu7T53akrFmMyGcsF3n5dO7MmwNBHKW5SV0",
+                "y": "SLW_xSffzlPWrHEVI30DHM_4egVwt3NQqeUD7nMFpps"
+            }
         }
 
         alg = JsonWebEncryption.ALG_REGISTRY['ECDH-1PU']
@@ -295,11 +312,125 @@ class JWETest(unittest.TestCase):
         bob_static_pubkey = bob_static_key.get_op_key('wrapKey')
         alice_ephemeral_pubkey = alice_ephemeral_key.get_op_key('wrapKey')
 
-        dk_at_alice = alg.deliver_at_sender(alice_static_key, alice_ephemeral_key, bob_static_pubkey, headers, 256, None)
+        dk_at_alice = alg.deliver_at_sender(
+            alice_static_key, alice_ephemeral_key, bob_static_pubkey, headers, 256, None)
         self.assertEqual(urlsafe_b64encode(dk_at_alice), b'bK8Tcj0UhQrUtCzW3ek1v_0v_wCpunDeBcIDpeFyLKc')
 
-        dk_at_bob = alg.deliver_at_recipient(bob_static_key, alice_static_pubkey, alice_ephemeral_pubkey, headers, 256, None)
-        self.assertEqual(urlsafe_b64encode(dk_at_bob), b'bK8Tcj0UhQrUtCzW3ek1v_0v_wCpunDeBcIDpeFyLKc')
+        dk_at_bob = alg.deliver_at_recipient(
+            bob_static_key, alice_static_pubkey, alice_ephemeral_pubkey, headers, 256, None)
+        self.assertEqual(dk_at_bob, dk_at_alice)
+
+    def test_ecdh_1pu_key_agreement_computation_appx_b(self):
+        # https://datatracker.ietf.org/doc/html/draft-madden-jose-ecdh-1pu-04#appendix-B
+        alice_static_key = {
+            "kty": "OKP",
+            "crv": "X25519",
+            "x": "Knbm_BcdQr7WIoz-uqit9M0wbcfEr6y-9UfIZ8QnBD4",
+            "d": "i9KuFhSzEBsiv3PKVL5115OCdsqQai5nj_Flzfkw5jU"
+        }
+        bob_static_key = {
+            "kty": "OKP",
+            "crv": "X25519",
+            "x": "BT7aR0ItXfeDAldeeOlXL_wXqp-j5FltT0vRSG16kRw",
+            "d": "1gDirl_r_Y3-qUa3WXHgEXrrEHngWThU3c9zj9A2uBg"
+        }
+        charlie_static_key = {
+            "kty": "OKP",
+            "crv": "X25519",
+            "x": "q-LsvU772uV_2sPJhfAIq-3vnKNVefNoIlvyvg1hrnE",
+            "d": "Jcv8gklhMjC0b-lsk5onBbppWAx5ncNtbM63Jr9xBQE"
+        }
+        alice_ephemeral_key = {
+            "kty": "OKP",
+            "crv": "X25519",
+            "x": "k9of_cpAajy0poW5gaixXGs9nHkwg1AFqUAFa39dyBc",
+            "d": "x8EVZH4Fwk673_mUujnliJoSrLz0zYzzCWp5GUX2fc8"
+        }
+
+        headers = OrderedDict({
+            "alg": "ECDH-1PU+A128KW",
+            "enc": "A256CBC-HS512",
+            "apu": "QWxpY2U",
+            "apv": "Qm9iIGFuZCBDaGFybGll",
+            "epk": OrderedDict({
+                "kty": "OKP",
+                "crv": "X25519",
+                "x": "k9of_cpAajy0poW5gaixXGs9nHkwg1AFqUAFa39dyBc"
+            })
+        })
+
+        cek = b'\xff\xfe\xfd\xfc\xfb\xfa\xf9\xf8\xf7\xf6\xf5\xf4\xf3\xf2\xf1\xf0' \
+              b'\xef\xee\xed\xec\xeb\xea\xe9\xe8\xe7\xe6\xe5\xe4\xe3\xe2\xe1\xe0' \
+              b'\xdf\xde\xdd\xdc\xdb\xda\xd9\xd8\xd7\xd6\xd5\xd4\xd3\xd2\xd1\xd0' \
+              b'\xcf\xce\xcd\xcc\xcb\xca\xc9\xc8\xc7\xc6\xc5\xc4\xc3\xc2\xc1\xc0'
+
+        iv = b'\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f'
+
+        payload = b'Three is a magic number.'
+
+        alg = JsonWebEncryption.ALG_REGISTRY['ECDH-1PU+A128KW']
+        enc = JsonWebEncryption.ENC_REGISTRY['A256CBC-HS512']
+
+        alice_static_key = OKPKey.import_key(alice_static_key)
+        bob_static_key = OKPKey.import_key(bob_static_key)
+        charlie_static_key = OKPKey.import_key(charlie_static_key)
+        alice_ephemeral_key = OKPKey.import_key(alice_ephemeral_key)
+
+        alice_static_pubkey = alice_static_key.get_op_key('wrapKey')
+        bob_static_pubkey = bob_static_key.get_op_key('wrapKey')
+        charlie_static_pubkey = charlie_static_key.get_op_key('wrapKey')
+        alice_ephemeral_pubkey = alice_ephemeral_key.get_op_key('wrapKey')
+
+        protected_segment = json_b64encode(headers)
+        aad = to_bytes(protected_segment, 'ascii')
+
+        ciphertext, tag = enc.encrypt(payload, aad, iv, cek)
+        self.assertEqual(urlsafe_b64encode(ciphertext), b'Az2IWsISEMDJvyc5XRL-3-d-RgNBOGolCsxFFoUXFYw')
+        self.assertEqual(urlsafe_b64encode(tag), b'HLb4fTlm8spGmij3RyOs2gJ4DpHM4hhVRwdF_hGb3WQ')
+
+        dk_at_alice_for_bob = alg.deliver_at_sender(
+            alice_static_key, alice_ephemeral_key, bob_static_pubkey, headers, 128, tag)
+        self.assertEqual(dk_at_alice_for_bob, b'\xdf\x4c\x37\xa0\x66\x83\x06\xa1\x1e\x3d\x6b\x00\x74\xb5\xd8\xdf')
+
+        kek_at_alice_for_bob = alg.aeskw.prepare_key(dk_at_alice_for_bob)
+        wrapped_for_bob = alg.aeskw.wrap_cek(cek, kek_at_alice_for_bob)
+        ek_for_bob = wrapped_for_bob['ek']
+        self.assertEqual(
+            urlsafe_b64encode(ek_for_bob),
+            b'pOMVA9_PtoRe7xXW1139NzzN1UhiFoio8lGto9cf0t8PyU-sjNXH8-LIRLycq8CHJQbDwvQeU1cSl55cQ0hGezJu2N9IY0QN')
+
+        dk_at_bob_for_alice = alg.deliver_at_recipient(
+            bob_static_key, alice_static_pubkey, alice_ephemeral_pubkey, headers, 128, tag)
+        self.assertEqual(dk_at_bob_for_alice, dk_at_alice_for_bob)
+
+        kek_at_bob_for_alice = alg.aeskw.prepare_key(dk_at_bob_for_alice)
+        cek_unwrapped_by_bob = alg.aeskw.unwrap(enc, ek_for_bob, headers, kek_at_bob_for_alice)
+        self.assertEqual(cek_unwrapped_by_bob, cek)
+
+        payload_decrypted_by_bob = enc.decrypt(ciphertext, aad, iv, tag, cek_unwrapped_by_bob)
+        self.assertEqual(payload_decrypted_by_bob, payload)
+
+        dk_at_alice_for_charlie = alg.deliver_at_sender(
+            alice_static_key, alice_ephemeral_key, charlie_static_pubkey, headers, 128, tag)
+        self.assertEqual(dk_at_alice_for_charlie, b'\x57\xd8\x12\x6f\x1b\x7e\xc4\xcc\xb0\x58\x4d\xac\x03\xcb\x27\xcc')
+
+        kek_at_alice_for_charlie = alg.aeskw.prepare_key(dk_at_alice_for_charlie)
+        wrapped_for_charlie = alg.aeskw.wrap_cek(cek, kek_at_alice_for_charlie)
+        ek_for_charlie = wrapped_for_charlie['ek']
+        self.assertEqual(
+            urlsafe_b64encode(ek_for_charlie),
+            b'56GVudgRLIMEElQ7DpXsijJVRSWUSDNdbWkdV3g0GUNq6hcT_GkxwnxlPIWrTXCqRpVKQC8fe4z3PQ2YH2afvjQ28aiCTWFE')
+
+        dk_at_charlie_for_alice = alg.deliver_at_recipient(
+            charlie_static_key, alice_static_pubkey, alice_ephemeral_pubkey, headers, 128, tag)
+        self.assertEqual(dk_at_charlie_for_alice, dk_at_alice_for_charlie)
+
+        kek_at_charlie_for_alice = alg.aeskw.prepare_key(dk_at_charlie_for_alice)
+        cek_unwrapped_by_charlie = alg.aeskw.unwrap(enc, ek_for_charlie, headers, kek_at_charlie_for_alice)
+        self.assertEqual(cek_unwrapped_by_charlie, cek)
+
+        payload_decrypted_by_charlie = enc.decrypt(ciphertext, aad, iv, tag, cek_unwrapped_by_charlie)
+        self.assertEqual(payload_decrypted_by_charlie, payload)
 
     def test_ecdh_1pu_jwe(self):
         jwe = JsonWebEncryption()

--- a/tests/core/test_jose/test_jwe.py
+++ b/tests/core/test_jose/test_jwe.py
@@ -6,7 +6,7 @@ from authlib.jose import errors, ECKey
 from authlib.jose import OctKey, OKPKey
 from authlib.jose import JsonWebEncryption
 from authlib.common.encoding import urlsafe_b64encode, json_b64encode, to_bytes
-from authlib.jose.errors import InappropriateEncryptionAlgorithmError
+from authlib.jose.errors import InvalidEncryptionAlgorithmForECDH1PUWithKeyWrappingError
 from tests.util import read_file_path
 
 
@@ -627,7 +627,7 @@ class JWETest(unittest.TestCase):
             ]:
                 protected = {'alg': alg, 'enc': enc}
                 self.assertRaises(
-                    InappropriateEncryptionAlgorithmError,
+                    InvalidEncryptionAlgorithmForECDH1PUWithKeyWrappingError,
                     jwe.serialize_compact,
                     protected, b'hello', bob_key, sender_key=alice_key
                 )

--- a/tests/core/test_jose/test_jws.py
+++ b/tests/core/test_jose/test_jws.py
@@ -173,7 +173,7 @@ class JWSTest(unittest.TestCase):
         protected = {'alg': 'HS256', 'invalid': 'k'}
         header = {'protected': protected, 'header': {'kid': 'a'}}
         self.assertRaises(
-            errors.InvalidHeaderParameterName,
+            errors.InvalidHeaderParameterNameError,
             jws.serialize, header, b'hello', 'secret'
         )
         jws = JsonWebSignature(private_headers=['invalid'])


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
    - Fixed a bug with a wrong size of the agreed upon key in direct key agreement mode of ECDH-ES and ECDH-1PU.
    - Prepended the shared secret computation in OKPKey class with lazy initialization of private_key field.
- [x] Feature
    - Added ECDH-1PU (Draft 04) algorithm support to JWE implementation.
    - Enhanced unit tests of ECDH-ES algorithm.
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No (while `JWEAlgorithm` is subclassed within Authlib only)

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
